### PR TITLE
Setup rating update

### DIFF
--- a/src/actions/actions.test.js
+++ b/src/actions/actions.test.js
@@ -39,18 +39,32 @@ describe('actions', () => {
     const user = {
         id: 1,
         name: 'placeholder',
-        email: 'placeholder'
+        email: 'placeholder',
+        ratings: []
       };
     const expectedAction = {
       type: 'UPDATE_USER',
       user: {
         id: 1,
         name: 'placeholder',
-        email: 'placeholder'
+        email: 'placeholder',
+        ratings: []
       }
     };
 
     const result = actions.updateUser(user);
+
+    expect(result).toEqual(expectedAction);
+  })
+
+  it('should have a type of UPDATE_LOGGEDIN_STATUS', () => {
+    const status = true;
+    const expectedAction = {
+      type: 'UPDATE_LOGGEDIN_STATUS',
+      status: true
+    };
+
+    const result = actions.updateLoggedInStatus(status);
 
     expect(result).toEqual(expectedAction);
   })
@@ -78,4 +92,26 @@ describe('actions', () => {
 
     expect(result).toEqual(expectedAction);
   })
+})
+
+it('should have a type of UPDATE_RATINGS', () => {
+  const ratings = [
+    {id: 1, user_id: 1, movie_id: 1, rating: 6,
+    created_at: "someDate", updated_at: "someDate"},
+    {id: 2, user_id: 1, movie_id: 2, rating: 2,
+      created_at: "secondDate", updated_at: "secondDate"}
+  ];
+  const expectedAction = {
+    type: 'UPDATE_RATINGS',
+    ratings: [
+      {id: 1, user_id: 1, movie_id: 1, rating: 6,
+      created_at: "someDate", updated_at: "someDate"},
+      {id: 2, user_id: 1, movie_id: 2, rating: 2,
+        created_at: "secondDate", updated_at: "secondDate"}
+    ]
+  };
+
+  const result = actions.updateRatings(ratings);
+
+  expect(result).toEqual(expectedAction);
 })

--- a/src/components/MovieShowPage.js
+++ b/src/components/MovieShowPage.js
@@ -2,6 +2,8 @@ import React from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import './MovieShowPage.css'
+import { updateUser, updateLoggedInStatus } from '../actions/index';
+
 
 export const MovieShowPage = props => {
   const {
@@ -12,6 +14,18 @@ export const MovieShowPage = props => {
     overview,
     average_rating
   } = props;
+
+// grab the value which will be the rating that we send through the POST
+// we get back a worthless return from POST
+// so we REFETCH ratings by invoking fetchRatings
+// that give us back the full updated array of ratings
+// const updatedRatings = whatever we get back from re-GET-fetchRatings
+// const updatedUserObj = {...state.user, ratings: updatedRatings}
+
+// updateRatings(fetchedRatings)
+
+
+
 
   return (
     <div className="movie-page">
@@ -41,11 +55,19 @@ export const MovieShowPage = props => {
 
 export const mapStateToProps = state => ({
   allMovies: state.movies,
-
+  isLoggedIn: state.isLoggedIn,
+  user: state.user
 });
 
-export default connect(mapStateToProps, null)(MovieShowPage);
+export const mapDispatchToProps = dispatch => ({
+  updateUser: user => dispatch(updateUser(user))
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(MovieShowPage);
 
 MovieShowPage.propTypes = {
-  allMovies: PropTypes.array
+  allMovies: PropTypes.array,
+  isLoggedIn: PropTypes.bool,
+  user: PropTypes.object,
+  updateUser: PropTypes.func
 };

--- a/src/components/MovieShowPage.js
+++ b/src/components/MovieShowPage.js
@@ -23,7 +23,21 @@ export const MovieShowPage = props => {
 // const updatedUserObj = {...state.user, ratings: updatedRatings}
 
 // updateRatings(fetchedRatings)
+const handleRatingsUpdates = () => {
+  console.log('got in')
+  const { updateUser, user } = props;
 
+  const newRatings = [
+    {id: 1, user_id: 1, movie_id: 1, rating: 6,
+    created_at: "someDate", updated_at: "someDate"},
+    {id: 2, user_id: 1, movie_id: 2, rating: 2,
+      created_at: "secondDate", updated_at: "secondDate"},
+    {id: 3, user_id: 1, movie_id: 3, rating: 3,
+      created_at: "thirdDate", updated_at: "thirdDate"}
+  ]
+  const createTestUserObj = {...user, ratings: newRatings}
+  console.log('USEROBJ: ', createTestUserObj);
+}
 
 
 
@@ -46,7 +60,8 @@ export const MovieShowPage = props => {
           <button className="rating-btn btn-seven" value="7">7</button>
           <button className="rating-btn btn-eight" value="8">8</button>
           <button className="rating-btn btn-nine" value="9">9</button>
-          <button className="rating-btn btn-ten" value="10">10</button>
+          <button className="rating-btn btn-ten" value="10"
+            onClick={handleRatingsUpdates}>10</button>
         </div>
       </div>
     </div>

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -9,7 +9,6 @@ const rootReducer = combineReducers({
   movies: moviesReducer,
   user: userReducer,
   isLoggedIn: isLoggedInReducer,
-  //Error and loading naming conventions need to be approved by teammates. Whatever offers most clarity
   errorMessage: errorReducer,
   loadingStatus: loadingStatusReducer,
 });

--- a/src/reducers/userReducer.js
+++ b/src/reducers/userReducer.js
@@ -2,8 +2,8 @@ export const userReducer = (state = {}, action) => {
   switch (action.type) {
     case 'UPDATE_USER':
       return action.user
-    case 'UPDATE_RATINGS':
-      return action.ratings
+    // case 'UPDATE_RATINGS':
+    //   return action.user
     default:
       return state;
   };

--- a/src/reducers/userReducer.test.js
+++ b/src/reducers/userReducer.test.js
@@ -20,4 +20,37 @@ describe('userReducer', () => {
 
     expect(result).toEqual(expectedState);
   });
+
+  // it('should return the correct state if the action is UPDATE_RATINGS', () => {
+  //   const initialState = {id: 1, name: 'Marge', email: 'marge@turing.io',
+  //     ratings: [
+  //       {id: 1, user_id: 1, movie_id: 1, rating: 6,
+  //       created_at: "someDate", updated_at: "someDate"},
+  //       {id: 2, user_id: 1, movie_id: 2, rating: 2,
+  //         created_at: "secondDate", updated_at: "secondDate"}
+  //     ]};
+  //   const action = {
+  //     type: 'UPDATE_RATINGS',
+  //     ratings: [
+  //       {id: 1, user_id: 1, movie_id: 1, rating: 6,
+  //       created_at: "someDate", updated_at: "someDate"},
+  //       {id: 2, user_id: 1, movie_id: 2, rating: 2,
+  //         created_at: "secondDate", updated_at: "secondDate"},
+  //       {id: 3, user_id: 1, movie_id: 3, rating: 3,
+  //         created_at: "thirdDate", updated_at: "thirdDate"}
+  //     ]
+  //   };
+  //
+  //   const result = userReducer(initialState, action);
+  //   const expectedState = {id: 1, name: 'Marge', email: 'marge@turing.io',
+  //     ratings: [
+  //       {id: 1, user_id: 1, movie_id: 1, rating: 6,
+  //       created_at: "someDate", updated_at: "someDate"},
+  //       {id: 2, user_id: 1, movie_id: 2, rating: 2,
+  //         created_at: "secondDate", updated_at: "secondDate"},
+  //       {id: 3, user_id: 1, movie_id: 3, rating: 3,
+  //         created_at: "thirdDate", updated_at: "thirdDate"}
+  //     ]};
+  //   expect(result).toEqual(expectedState);
+  // })
 });

--- a/src/reducers/userReducer.test.js
+++ b/src/reducers/userReducer.test.js
@@ -2,20 +2,21 @@ import { userReducer } from '../reducers/userReducer';
 
 describe('userReducer', () => {
   it('should return the initial state', () => {
-    const expected = {id: '', name: '', email: ''};
+    const expected = {};
     const result = userReducer(undefined, {});
 
     expect(result).toEqual(expected);
   });
 
   it('should return the correct state if the action is UPDATE_USER', () => {
-    const initialState = {id: '', name: '', email: ''};
+    const initialState = {};
     const action = {
       type: 'UPDATE_USER',
-      user: {id: 1, name: 'placeholder', email: 'placeholder'}
+      user: {id: 1, name: 'placeholder', email: 'placeholder', ratings: []}
     };
     const result = userReducer(initialState, action);
-    const expectedState = {id: 1, name: 'placeholder', email: 'placeholder'};
+    const expectedState = {id: 1, name: 'placeholder',
+      email: 'placeholder', ratings: []};
 
     expect(result).toEqual(expectedState);
   });


### PR DESCRIPTION
### What's this PR do?
- Works through options for our next steps to be able to POST new ratings and re-invoke `fetchRatings` to GET the updated ratings after POST is completed.   
- Lots of comments and test/pseudocode was left in these files since we are still working through this.  Hopefully our plan works and we can just delete the commented out UPDATE_RATINGS test but if we have to go back to it we don't want to have to re-write it.
- Passes off the next steps to @peeratmac 

### Where should the reviewer start?
- Look at the test/psuedocode in MovieShowPage
- the `console.log` shows that we can create the updated user object then pass it through the existing `UPDATE_USER` action creator rather than adding a 2nd action creator.

### How should this be manually tested?
- A snapshot test is failing because I added an onClick.  We will have many updates to this snapshot as we continue to update this component so we can `U` or ignore until we're close to the final product.

### What are the relevant tickets?
- Continues working through issue #6 but does not complete it

### Screenshots (if appropriate)

This is the user object that is console logged by the last line of the 2nd screenshot.  It is in the format that we want to that we can pass it through to the updateUser() action creator to update the store.

![Screen Shot 2019-12-21 at 3 33 55 PM](https://user-images.githubusercontent.com/48163945/71314645-5eae2c80-2409-11ea-9ddb-3fe22e26f051.jpg)


![Screen Shot 2019-12-21 at 3 34 24 PM](https://user-images.githubusercontent.com/48163945/71314647-68379480-2409-11ea-8481-c6aa264ff707.jpg)
