### PR TITLE
User score

### DIFF
--- a/src/components/MovieCard.css
+++ b/src/components/MovieCard.css
@@ -65,10 +65,11 @@
 .average-score {
   color: #3B397F;
   font-size: 20px;
+  font-weight: bold;
   left: 4px;
   position: relative;
   text-align: center;
-  text-shadow: 0px 0px 1px black;
+  text-shadow: 0px 0px 1px purple;
   top: -42px;
   z-index: 1;
 }
@@ -86,4 +87,65 @@
 .view-movie:hover {
   color: #D45DC1;
   text-shadow: 10px 15px 3px black;
+}
+
+.star-container {
+  height: 85px;
+  margin-top: -85px;
+  position: relative;
+  text-shadow: 3px 3px 3px black;
+  top: 65px;
+  width: 200px;
+  z-index: 1;
+}
+
+.star-container:before {
+  bottom: 20px;
+  color: white;
+  content: 'Your ';
+  font-family: 'Hanalei Fill', cursive;
+  font-size: 18px;
+  left: 29px;
+  position: relative;
+}
+
+.star-container:after {
+  bottom: 20px;
+  color: white;
+  content: 'Score';
+  font-family: 'Hanalei Fill', cursive;
+  font-size: 17px;
+  left: -10px;
+  position: relative;
+}
+
+.user-star {
+  height: 80px;
+  position: relative;
+  left: 21px;
+}
+
+.user-score {
+  color: #3B397F;
+  font-size: 20px;
+  font-weight: bold;
+  left: -32px;
+  position: relative;
+  text-align: center;
+  text-shadow: 0px 0px 1px pink;
+  top: -26px;
+  z-index: 2;
+}
+
+.user__score--two {
+  color: #3B397F;
+  font-size: 20px;
+  font-weight: bold;
+  left: -26px;
+  margin-right: 9px;
+  position: relative;
+  text-align: center;
+  text-shadow: 0px 0px 1px pink;
+  top: -26px;
+  z-index: 2;
 }

--- a/src/components/MovieCard.js
+++ b/src/components/MovieCard.js
@@ -15,9 +15,34 @@ export const MovieCard = props => {
     average_rating
   } = props;
 
+  const { isLoggedIn, user } = props;
+
+  const findUserRating = id => {
+    if (isLoggedIn && user.ratings) {
+      const userRatings = user.ratings.map(ratedFilm => ratedFilm.movie_id);
+        if (userRatings.includes(id)) {
+          return user.ratings.find(movie => movie.movie_id === id).rating;
+        } else {
+          return '...';
+        }
+    }
+  };
+
   return (
     <div className="movie-card">
       <h1 className="poster-title">{title}</h1>
+      {isLoggedIn && findUserRating(id) !== '...' &&
+        <div className='star-container'>
+          <img
+            className='user-star'
+            src='https://img.icons8.com/officel/80/000000/filled-star.png'
+            alt='cartoon star'
+          />
+          <span className={findUserRating(id) === 10 ? 'user-score': 'user__score--two'}>
+            {findUserRating(id)}
+          </span>
+        </div>
+      }
       <img
         className='poster'
         src={poster_path}
@@ -40,7 +65,12 @@ export const MovieCard = props => {
   );
 };
 
-export default MovieCard;
+export const mapStateToProps = state => ({
+  isLoggedIn: state.isLoggedIn,
+  user: state.user
+});
+
+export default connect(mapStateToProps, null)(MovieCard);
 
 MovieCard.propTypes = {
   id: PropTypes.number,

--- a/src/components/MovieCard.test.js
+++ b/src/components/MovieCard.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { MovieCard } from './MovieCard';
+import { MovieCard, mapStateToProps, mapDispatchToProps } from './MovieCard';
+
 
 describe('MovieCard', () => {
   let wrapper;
@@ -24,5 +25,21 @@ describe('MovieCard', () => {
     );
 
     expect(wrapper).toMatchSnapshot();
+  });
+
+  describe('mapsStateToProps', () => {
+    it('should return only the necessary information from the redux store', () => {
+      const mockState = {
+        isLoggedIn: true,
+        user: {newUser: 'Anonymous'}
+      };
+      const expected = {
+        isLoggedIn: true,
+        user: {newUser: 'Anonymous'}
+      };
+      const mappedProps = mapStateToProps(mockState);
+
+      expect(mappedProps).toEqual(expected);
+    });
   });
 });


### PR DESCRIPTION
## What's this PR do?
- Builds out the conditional rendering of user scores on the Movie Cards (on the homepage)
- Connects the MovieCard component to the store to retrieve user info & logged in status 
- Adds a mapStateToProps test into the MovieCard test suite
- Uses tricky CSS as a compromise meant to preserve the original spacing across both login statuses (more info below)

## Where should the reviewer start?
- Check out the attached screenshots to see if the chosen display suffices to avoid disgusting you. Definitely do not approve this PR if you dislike this rough draft of the presentation.
- Run the test suite to make sure that everything is still passing with the addition of a new test
- Run the server and observe the homepage under each login status

## What are the relevant tickets?
- #49 

## Is there any background information to provide?
- MovieCard is a component that prior to this PR was passed props from a parent component (MovieContainer). I've since connected it to the store so that I could access the user's ratings. Is it possible that doubly passing props might cause some issues? Everything seems to be working alright, but I wanted to at least bring this to your attention.
- In my effort to preserve vertical space so that the full extent of the first row of movie cards displays down to the view movie button link on page load, I did some strange things with the positioning of the user rating elements that appear once a user logs in and has rated the film in question. Adjusting the styling is tricky as a result. There'll be pixel-pushing required to amend things since I cooked up a bramble patch of relative-positioning, pseudo-elements, and z-index.
- Does the whole first row of movies present down to the 'View Movie' link when ya'll run your servers on your machines? I hide my dock, so maybe that's giving me a longer view height than what's typical?
- In order to display the user rating, I brought over the identical function we'd built to find the user rating from the MovieShowPage.js file. With the same function being repeated in separate files, am I missing an opportunity to DRY up the code? What would be the best approach to doing so (if necessary)?
- We can alternatively display the 'Your Score' rating below the average rating while reducing the movie poster sizes

**Images:**
- Logged Out:
![image](https://user-images.githubusercontent.com/42498559/71712170-4521c300-2dc1-11ea-885b-3d9e66802b0d.png)

- Logged In:
![image](https://user-images.githubusercontent.com/42498559/71712189-5a96ed00-2dc1-11ea-9473-ce5d1625e918.png)


- Alternative display option  (code is not included in this PR but cached locally if needed) -Posters are sized and spaced differently in order to fit the user rating below the tomato score (less of a seamless transition between login states, but avoids the issues with superimposing the elements on top of the film posters)
![image](https://user-images.githubusercontent.com/42498559/71745143-9021f180-2e26-11ea-9be2-c6cf08006e63.png)




