### PR TITLE
Invalid routes

### DIFF
--- a/src/apiCalls.test.js
+++ b/src/apiCalls.test.js
@@ -174,6 +174,16 @@ describe('apiCalls', () => {
         'Content-Type': 'application/json'
       }
     };
+    beforeEach(() => {
+      window.fetch = jest.fn().mockImplementation(() => {
+        return Promise.resolve({
+          ok: true,
+          json: () => {
+            return Promise.resolve(mockResponse);
+          }
+        });
+      });
+    });
 
     it('should passed the correct URL', () => {
       updateRatings(mockMovieId, mockRating, mockUserId);
@@ -213,6 +223,17 @@ describe('apiCalls', () => {
         'Content-Type': 'application/json'
       }
     };
+
+    beforeEach(() => {
+      window.fetch = jest.fn().mockImplementation(() => {
+        return Promise.resolve({
+          ok: true,
+          json: () => {
+            return Promise.resolve(mockResponse);
+          }
+        });
+      });
+    });
 
     it('should passed the correct URL', () => {
       deleteRating(mockRatingId, mockUserId);

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -37,14 +37,11 @@ export class App extends Component {
             render={({ match }) => {
               const { id } = match.params;
               let moviesData = this.props.allMovies.find(
-                movie => movie.id === parseInt(id)
-              );
-              return <MovieShowPage {...moviesData} />;
+                movie => movie.id === parseInt(id));
+              return moviesData ? <MovieShowPage {...moviesData} /> : <NoMatch />
             }}
           />
-          <Route>
-            <NoMatch />
-          </Route>
+          <Route component={NoMatch} />
         </Switch>
       </main>
     );

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -2,11 +2,12 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { fetchAllMovies } from '../apiCalls';
 import { addMovies } from '../actions/index';
-import { Route } from 'react-router-dom';
+import { Route, Switch } from 'react-router-dom';
 import NavigationBar from '../containers/NavigationBar';
 import MovieContainer from '../containers/MovieContainer';
 import MovieShowPage from '../components/MovieShowPage';
 import LoginForm from '../containers/LoginForm';
+import NoMatch from '../components/NoMatch';
 import { handleError, isLoading } from '../actions';
 import PropTypes from 'prop-types';
 
@@ -27,19 +28,24 @@ export class App extends Component {
     return (
       <main>
         <NavigationBar />
-        <Route exact path='/' component={MovieContainer} />
-        <Route exact path='/login' component={LoginForm} />
-        <Route
-          exact
-          path='/movies/:id'
-          render={({ match }) => {
-            const { id } = match.params;
-            let moviesData = this.props.allMovies.find(
-              movie => movie.id === parseInt(id)
-            );
-            return <MovieShowPage {...moviesData} />;
-          }}
-        />
+        <Switch>
+          <Route exact path='/' component={MovieContainer} />
+          <Route exact path='/login' component={LoginForm} />
+          <Route
+            exact
+            path='/movies/:id'
+            render={({ match }) => {
+              const { id } = match.params;
+              let moviesData = this.props.allMovies.find(
+                movie => movie.id === parseInt(id)
+              );
+              return <MovieShowPage {...moviesData} />;
+            }}
+          />
+          <Route>
+            <NoMatch />
+          </Route>
+        </Switch>
       </main>
     );
   };

--- a/src/components/MovieCard.js
+++ b/src/components/MovieCard.js
@@ -17,7 +17,9 @@ export const MovieCard = props => {
 
   return (
     <div className="movie-card">
-      <h1 className="poster-title">{title}</h1>
+      <NavLink to={`/movies/${id}`} style={{ textDecoration: 'none'}}>
+        <h1 className="poster-title">{title}</h1>
+      </NavLink>
       {isLoggedIn && user.ratings && findRating(id, user, 'rating') !== '...' &&
         <div className='star-container'>
           <img
@@ -31,11 +33,13 @@ export const MovieCard = props => {
           </span>
         </div>
       }
-      <img
-        className='poster'
-        src={poster_path}
-        alt={`Movie Poster of ${title}`}
-      />
+      <NavLink to={`/movies/${id}`} style={{ textDecoration: 'none'}}>
+        <img
+          className='poster'
+          src={poster_path}
+          alt={`Movie Poster of ${title}`}
+        />
+      </NavLink>
       <div className='avg-container'>
         <img
           className='average-img'
@@ -46,9 +50,6 @@ export const MovieCard = props => {
       <span className='average-score'>
         {average_rating.toFixed(1)}
       </span>
-      <NavLink to={`/movies/${id}`} style={{ textDecoration: 'none'}}>
-        <div className="view-movie">View Movie</div>
-      </NavLink>
     </div>
   );
 };

--- a/src/components/NoMatch.css
+++ b/src/components/NoMatch.css
@@ -1,0 +1,24 @@
+.no-match {
+  align-items: center;
+  background: linear-gradient(rgba(0, 0, .5, .5), rgba(0, .1, .1, .1)), url("../images/curtains.jpeg");
+  background-blend-mode: lighten saturation;
+  background-repeat: no-repeat;
+  background-size: 100% 100%;
+  border: 5px double #C654DE;
+  box-sizing: border-box;
+  color: #D45DC1;
+  display: flex;
+  flex-direction: column;
+  height: 92vh;
+  justify-content: space-around;
+  margin: 0px;
+  overflow: scroll;
+}
+
+.invalid-route-header {
+
+}
+
+.invalid-route-button {
+
+}

--- a/src/components/NoMatch.css
+++ b/src/components/NoMatch.css
@@ -10,15 +10,32 @@
   display: flex;
   flex-direction: column;
   height: 92vh;
-  justify-content: space-around;
   margin: 0px;
   overflow: scroll;
 }
 
 .invalid-route-header {
-
+  font-size: 3em;
+  margin: 120px 120px 55px 120px;
+  text-align: center;
 }
 
 .invalid-route-button {
+  background-color: #34032f;
+  border: 0.1px groove #c554dd;
+  border-radius: 3px;
+  box-shadow: 0 0 1px 1px white;
+  color: white;
+  font-size: 20px;
+  font-weight: bold;
+  height: 45px;
+  line-height: 5px;
+  outline: none;
+  width: 221px;
+}
 
+.invalid-route-button:hover {
+  background-color: #c654dd;
+  border: 1px groove black;
+  color: white;
 }

--- a/src/components/NoMatch.js
+++ b/src/components/NoMatch.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
+import './NoMatch.css';
 
 
 const NoMatch = () => {

--- a/src/components/NoMatch.js
+++ b/src/components/NoMatch.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+
+const NoMatch = () => {
+  return (
+    <div className='no-match'>
+      <h2 className='invalid-route-header'>Uh-oh! Page Not Found</h2>
+      <Link to ='/'>
+        <button className='invalid-route-button'>Return To Homepage</button>
+      </Link>
+    </div>
+  )
+}
+
+export default NoMatch;

--- a/src/components/NoMatch.test.js
+++ b/src/components/NoMatch.test.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import NoMatch from './NoMatch';
+
+describe('NoMatch', () => {
+  let wrapper;
+
+  it('should match snapshot', () => {
+    wrapper = shallow(<NoMatch />);
+    expect(wrapper).toMatchSnapshot();
+  })
+})

--- a/src/components/__snapshots__/App.test.js.snap
+++ b/src/components/__snapshots__/App.test.js.snap
@@ -3,36 +3,41 @@
 exports[`App should match the App Snapshot 1`] = `
 <main>
   <Connect(NavigationBar) />
-  <Route
-    component={
-      Object {
-        "$$typeof": Symbol(react.memo),
-        "WrappedComponent": [Function],
-        "compare": null,
-        "displayName": "Connect(MovieContainer)",
-        "type": [Function],
+  <Switch>
+    <Route
+      component={
+        Object {
+          "$$typeof": Symbol(react.memo),
+          "WrappedComponent": [Function],
+          "compare": null,
+          "displayName": "Connect(MovieContainer)",
+          "type": [Function],
+        }
       }
-    }
-    exact={true}
-    path="/"
-  />
-  <Route
-    component={
-      Object {
-        "$$typeof": Symbol(react.memo),
-        "WrappedComponent": [Function],
-        "compare": null,
-        "displayName": "Connect(LoginForm)",
-        "type": [Function],
+      exact={true}
+      path="/"
+    />
+    <Route
+      component={
+        Object {
+          "$$typeof": Symbol(react.memo),
+          "WrappedComponent": [Function],
+          "compare": null,
+          "displayName": "Connect(LoginForm)",
+          "type": [Function],
+        }
       }
-    }
-    exact={true}
-    path="/login"
-  />
-  <Route
-    exact={true}
-    path="/movies/:id"
-    render={[Function]}
-  />
+      exact={true}
+      path="/login"
+    />
+    <Route
+      exact={true}
+      path="/movies/:id"
+      render={[Function]}
+    />
+    <Route
+      component={[Function]}
+    />
+  </Switch>
 </main>
 `;

--- a/src/components/__snapshots__/MovieCard.test.js.snap
+++ b/src/components/__snapshots__/MovieCard.test.js.snap
@@ -4,16 +4,34 @@ exports[`MovieCard should match the MovieCard Snapshot 1`] = `
 <div
   className="movie-card"
 >
-  <h1
-    className="poster-title"
+  <NavLink
+    style={
+      Object {
+        "textDecoration": "none",
+      }
+    }
+    to="/movies/3"
   >
-    Frozen II
-  </h1>
-  <img
-    alt="Movie Poster of Frozen II"
-    className="poster"
-    src="https://image.tmdb.org/t/p/original//pjeMs3yqRmFL3giJy4PMXWZTTPa.jpg"
-  />
+    <h1
+      className="poster-title"
+    >
+      Frozen II
+    </h1>
+  </NavLink>
+  <NavLink
+    style={
+      Object {
+        "textDecoration": "none",
+      }
+    }
+    to="/movies/3"
+  >
+    <img
+      alt="Movie Poster of Frozen II"
+      className="poster"
+      src="https://image.tmdb.org/t/p/original//pjeMs3yqRmFL3giJy4PMXWZTTPa.jpg"
+    />
+  </NavLink>
   <div
     className="avg-container"
   >
@@ -28,19 +46,5 @@ exports[`MovieCard should match the MovieCard Snapshot 1`] = `
   >
     8.0
   </span>
-  <NavLink
-    style={
-      Object {
-        "textDecoration": "none",
-      }
-    }
-    to="/movies/3"
-  >
-    <div
-      className="view-movie"
-    >
-      View Movie
-    </div>
-  </NavLink>
 </div>
 `;

--- a/src/components/__snapshots__/NoMatch.test.js.snap
+++ b/src/components/__snapshots__/NoMatch.test.js.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`NoMatch should match snapshot 1`] = `
+<div
+  className="no-match"
+>
+  <h2
+    className="invalid-route-header"
+  >
+    Uh-oh! Page Not Found
+  </h2>
+  <Link
+    to="/"
+  >
+    <button
+      className="invalid-route-button"
+    >
+      Return To Homepage
+    </button>
+  </Link>
+</div>
+`;

--- a/src/containers/NavigationBar.css
+++ b/src/containers/NavigationBar.css
@@ -3,7 +3,8 @@
   background-color: #2d2d2f;
   display: flex;
   height: 8vh;
-  justify-content: space-around;
+  justify-content: space-between;
+  padding: 0 15px;
 }
 
 .welcome-user {


### PR DESCRIPTION
### What's this PR do?
- Adds `NoMatch` component and router set up to route to a "Page Not Found" view when invalid route is entered.
  - Styling added to `NoMatch` component to match the rest of the app.
- Updates styling based on user testing feedback
  - Moves Nav Bar buttons closer to end of screen
  - Removes `View Movie` link and turns movie poster and title into links instead

### Where should the reviewer start?
- See if you approve of the styling/UX changes
- Try an invalid route
  - `http://localhost:3000/kk`
  - `http://localhost:3000/movies/289`

### How should this be manually tested?
- Test suite has added snapshot test for NoMatch and updated snapshot for App

### Any background context you want to provide?
- Had to add `<Switch>` to prevent duplicate running of No Match component.
- Please look at the snapshot in App.  When I was updating it I noticed it looked a little off. We can review together Monday.  I did not have time to investigate further.

### What are the relevant tickets?
Issue #54 and Issue #62 
-Found strange edge-case bug where `Ratings` does not display to the right of the tomato for the `Average Ratings` display on the homepage when user navigates to an invalid page then back to home.  Issue #63 has been opened for this bug.